### PR TITLE
Fix formatting of dict['priority'] === 0 (should remain 0, not 4)

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -143,7 +143,7 @@ class Formatter {
         const workDict = {};
         //amqp header
         workDict['durable'] = dict['durable'];
-        workDict['priority'] = !dict['priority'] ? 4 : dict['priority'];
+        workDict['priority'] = dict['priority'] == null ? 4 : dict['priority'];
         workDict['ttl'] = dict['ttl'];
         workDict['first-acquirer'] = dict['first_acquirer'];
         workDict['delivery-count'] = dict['delivery_count'];
@@ -196,7 +196,7 @@ class Formatter {
         const workDict = {};
         //amqp header
         workDict['durable'] = dict['durable'];
-        workDict['priority'] = !dict['priority'] ? 4 : dict['priority'];
+        workDict['priority'] = dict['priority'] == null ? 4 : dict['priority'];
         workDict['ttl'] = dict['ttl'];
         workDict['first_acquirer'] = dict['first_acquirer'];
         workDict['delivery_count'] = dict['delivery_count'];


### PR DESCRIPTION
Previously, `!dict['priority']` would be !0, which evaluates to true.
Now, the condition is true only if `dict[priority]` is null or undefined.