### PR TITLE
Skip building docs on node < 8 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ script:
   - docker run --rm -v`pwd`/scripts:/mnt -p 5672:5672 -p 61616:61616 --entrypoint ash enkeys/alpine-openjdk-amq7-snapshot /mnt/entrypoint.sh amq7-server &
   - sleep 10
   - npm run-script browserify
-  - npm run-script doc
+  - [[ ${TRAVIS_NODE_VERSION} -ge 8 ]] && npm run-script doc
   - npm run-script test


### PR DESCRIPTION
On versions < 8 it would fail, because unsupported features of node will be used.