### PR TITLE
Fixed issue with retry logic on released messages

### DIFF
--- a/lib/senderClient.js
+++ b/lib/senderClient.js
@@ -32,6 +32,7 @@ class Sender extends CoreClient {
         super();
         this.confirmed = 0;
         this.sent = 0;
+        this.released = 0;
         this.ts;
         this.timer_task;
         this._setUpHandlers();
@@ -113,7 +114,12 @@ class Sender extends CoreClient {
             this._nextRequest(context, this);
         } else {
             let message = undefined;
-            while ((this.options.anonymous || (context.sender && context.sender.sendable())) && this.sent < this.options.count) {
+            let totalSent = this.sent;
+            // If using best-effort, then simply ignore released messages
+            if (!this.options.linkAtMostOnce) {
+                totalSent -= this.released;
+            }
+            while ((this.options.anonymous || (context.sender && context.sender.sendable())) && totalSent < this.options.count) {
                 this.sent++;
                 message = this._createMessage(this.sent - 1);
 
@@ -213,9 +219,12 @@ class Sender extends CoreClient {
 
         //release message
         this.container.on('released', function (context) {
+            self.released++;
             self.onReleased(context);
-            if (self.options.releaseAction === 'retry') {
-                context.sender.send(context.delivery);
+            if (self.options.releaseAction === 'retry' && !self.options.linkAtMostOnce) {
+                if (context.sender.sendable()) {
+                    context.sender.send(context.delivery);
+                }
             }
         });
 


### PR DESCRIPTION
This resolves an issue with released messages that were causing sender to either get stuck or fail with an error that was similar to: https://github.com/amqp/rhea/issues/25.
